### PR TITLE
Pythorch Mish() improvement 

### DIFF
--- a/utils/layers.py
+++ b/utils/layers.py
@@ -11,7 +11,8 @@ try:
 except:
     class Mish(nn.Module):  # https://github.com/digantamisra98/Mish
         def forward(self, x):
-            return x * F.softplus(x).tanh()
+            # return x * F.softplus(x).tanh()
+            return F.mish(x)    
 
 
 class Reorg(nn.Module):


### PR DESCRIPTION
when I tested Tesla P100, using `return F.mish(x)` insted of `return x * F.softplus(x).tanh()` significantly reduced GPU memory usage.