### PR TITLE
Fix inference for single-class models.

### DIFF
--- a/models/models.py
+++ b/models/models.py
@@ -347,6 +347,8 @@ class YOLOLayer(nn.Module):
             #io[..., 2:4] = torch.exp(io[..., 2:4]) * self.anchor_wh  # wh yolo method
             #io[..., :4] *= self.stride
             #torch.sigmoid_(io[..., 4:])
+            if self.nc == 1:
+                io[..., 5] = 1
             return io.view(bs, -1, self.no), p  # view [1, 3, 13, 13, 85] as [1, 507, 85]
 
 


### PR DESCRIPTION
This change addresses the issue discussed here in the Ultralytics YOLOv3 repository:
https://github.com/ultralytics/yolov3/issues/235. 

Namely, that confidence score outputs for models trained in the single-class setting are incorrect.

My fix is identical to the one merged into the original repository by https://github.com/ultralytics/yolov3/commit/09ee7b6f115d96a377558492e05f7ef703d1c390